### PR TITLE
feat: enhance `Paginate` trait to support multiple implementation

### DIFF
--- a/src/pagination/paginator/contract/paginate.rs
+++ b/src/pagination/paginator/contract/paginate.rs
@@ -1,14 +1,15 @@
 use crate::pagination::{Paged, Pagination};
-use sea_orm::{ConnectionTrait, DbErr, SelectorTrait};
+use sea_orm::{ConnectionTrait, DbErr};
 
-pub trait Paginate<'db, C, S>
+pub trait Paginate<'db, C>
 where
     C: ConnectionTrait,
-    S: SelectorTrait,
 {
+    type Selector;
+
     fn paginate(
         self,
         conn: &'db C,
         pagination: &Pagination,
-    ) -> impl Future<Output = Result<Paged<S::Item>, DbErr>>;
+    ) -> impl Future<Output = Result<Paged<Self::Selector>, DbErr>>;
 }


### PR DESCRIPTION
- Removed `SelectorTrait` bound from `Paginate`.
- Added `Selector` associated type for flexibility in selector usage.
- Implemented `Paginate` for both `Selector<S>` and `Select<E>` types.